### PR TITLE
t6320: Fix Safari login: remove /auth prefix from Keycloak URL

### DIFF
--- a/src/keycloak-config.ts
+++ b/src/keycloak-config.ts
@@ -13,7 +13,7 @@ export default function getClient() {
   const config: MasterConfig = store.getters.config
   
   let returnClient = {
-    url: 'https://login.scoutsengidsenvlaanderen.be/auth',
+    url: 'https://login.scoutsengidsenvlaanderen.be',
     realm: "scouts",
     clientId: config.oidc.clientId,
     onLoad: OnLoadOptions.LOGIN_REQUIRED,


### PR DESCRIPTION
Keycloak 17 no longer uses /auth. Other browsers have redirected this endpoint, except for safari.